### PR TITLE
Fix: The GameCreated-Event now has the correct gameId;

### DIFF
--- a/src/main/kotlin/microservice/dungeon/game/aggregates/game/servives/GameService.kt
+++ b/src/main/kotlin/microservice/dungeon/game/aggregates/game/servives/GameService.kt
@@ -51,8 +51,7 @@ class GameService @Autowired constructor(
         var commandCollectionTime = game.getRoundDuration().toDouble()
         commandCollectionTime *= 0.75
         newGame.setCommandCollectDuration(commandCollectionTime)
-        gameRepository.save(newGame)
-        val gameCreated = GameCreated(game)
+        val gameCreated = GameCreated(gameRepository.save(newGame))
         eventStoreService.storeEvent(gameCreated)
         eventPublisherService.publishEvents(listOf(gameCreated))
         return newGame


### PR DESCRIPTION
Fixed the GameCreated-Event having the wrong gameId, by putting the correct Game object into the GameCreated-Constructor.